### PR TITLE
Atomic With a Separate Queue

### DIFF
--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -491,8 +491,11 @@ atomicMkFn = Nam "atomiq_init"
 atomicFinalize :: CCode Name
 atomicFinalize = Nam "atomiq_finalize"
 
-atomicDestroy :: CCode Name
-atomicDestroy = Nam "atomiq_destroy"
+atomicStart :: CCode Name
+atomicStart = Nam "atomiq_start"
+
+atomicStop :: CCode Name
+atomicStop = Nam "atomiq_stop"
 
 closureMkFn :: CCode Name
 closureMkFn = Nam "closure_mk"

--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -485,11 +485,17 @@ arrayMkFn = Nam "array_mk"
 tupleMkFn :: CCode Name
 tupleMkFn = Nam "tuple_mk"
 
+messageqWrapper :: CCode Ty
+messageqWrapper = Typ "messageq_wrapper_t"
+
 atomicMkFn :: CCode Name
 atomicMkFn = Nam "atomiq_init"
 
 atomicFinalize :: CCode Name
 atomicFinalize = Nam "atomiq_finalize"
+
+atomicSetq :: CCode Name
+atomicSetq = Nam "atomiq_setq"
 
 atomicStart :: CCode Name
 atomicStart = Nam "atomiq_start"

--- a/src/back/CodeGen/CCodeNames.hs
+++ b/src/back/CodeGen/CCodeNames.hs
@@ -485,6 +485,15 @@ arrayMkFn = Nam "array_mk"
 tupleMkFn :: CCode Name
 tupleMkFn = Nam "tuple_mk"
 
+atomicMkFn :: CCode Name
+atomicMkFn = Nam "atomiq_init"
+
+atomicFinalize :: CCode Name
+atomicFinalize = Nam "atomiq_finalize"
+
+atomicDestroy :: CCode Name
+atomicDestroy = Nam "atomiq_destroy"
+
 closureMkFn :: CCode Name
 closureMkFn = Nam "closure_mk"
 

--- a/src/back/CodeGen/ClassDecl.hs
+++ b/src/back/CodeGen/ClassDecl.hs
@@ -98,10 +98,10 @@ dispatchFunDecl cdecl@(A.Class{A.cname, A.cfields, A.cmethods}) =
                                            AsExpr $ (Var "msg") `Arrow` (Nam "argc"),
                                            AsExpr $ (Var "msg") `Arrow` (Nam "argv")]]])
        atomicStart =
-           (Nam "_ENC__MSG_ATOMIC_START,",
+           (Nam "_ENC__MSG_ATOMIC_START",
             Assign ((Var "_a") `Arrow` (Nam "read")) $ (Cast (Ptr $ Typ "pony_msgp_t") (Var "_m")) `Arrow` Nam "p")
        atomicStop =
-           (Nam "_ENC__MSG_ATOMIC_STOP,",
+           (Nam "_ENC__MSG_ATOMIC_STOP",
             Seq $ [Statement $ Call atomicDestroy [AsExpr $ (Var "_a") `Arrow` (Nam "read")],
                    Assign ((Var "_a") `Arrow` (Nam "read")) $ ((Var "_a") `Arrow` (Nam "write"))])
 

--- a/src/back/CodeGen/ClassDecl.hs
+++ b/src/back/CodeGen/ClassDecl.hs
@@ -97,12 +97,20 @@ dispatchFunDecl cdecl@(A.Class{A.cname, A.cfields, A.cmethods}) =
                                           [AsExpr encoreCtxVar,
                                            AsExpr $ (Var "msg") `Arrow` (Nam "argc"),
                                            AsExpr $ (Var "msg") `Arrow` (Nam "argv")]]])
+       atomicStart =
+           (Nam "_ENC__MSG_ATOMIC_START,",
+            Assign ((Var "_a") `Arrow` (Nam "read")) $ (Cast (Ptr $ Typ "pony_msgp_t") (Var "_m")) `Arrow` Nam "p")
+       atomicStop =
+           (Nam "_ENC__MSG_ATOMIC_STOP,",
+            Seq $ [Statement $ Call atomicDestroy [AsExpr $ (Var "_a") `Arrow` (Nam "read")],
+                   Assign ((Var "_a") `Arrow` (Nam "read")) $ ((Var "_a") `Arrow` (Nam "write"))])
+
        methodClauses = concatMap methodClause
 
-       methodClause m = (mthdDispatchClause m mArgs) :
-                         if not (A.isStreamMethod m)
-                         then [oneWaySendDispatchClause m mArgs]
-                         else []
+       methodClause m = atomicStart : atomicStop : (mthdDispatchClause m mArgs) :
+                        if not (A.isStreamMethod m)
+                        then [oneWaySendDispatchClause m mArgs]
+                        else []
          where
            mArgs = (A.methodName &&& A.methodParams) m
 

--- a/src/back/CodeGen/Expr.hs
+++ b/src/back/CodeGen/Expr.hs
@@ -760,17 +760,21 @@ instance Translatable A.Expr (State Ctx.Context (CCode Lval, CCode Stat)) where
 
   translate (A.Atomic {A.target, A.name, A.body}) =
       do (_, tbody)   <- translate body
-         new <- Ctx.genNamedSym "new"
-         old <- Ctx.genNamedSym "old"
-         ctx <- get
+         msgq <- Ctx.genNamedSym "q"
+         new  <- Ctx.genNamedSym "new"
+         old  <- Ctx.genNamedSym "old"
+         ctx  <- get
          let atom = case Ctx.substLkp ctx (ID.qLocal name) of
                       Just substName -> substName
                       Nothing -> error $ "WELP: " ++ (show name)
              targetTy = translate $ A.getType target
-             atomInit = Seq $ [Assign (Decl (targetTy, Var new)) (Cast targetTy
-                                      (Call atomicMkFn [AsExpr encoreCtxVar, Cast (Ptr ponyActorT) atom])),
+             atomInit = Seq $ [Assign (Decl (Ptr messageqWrapper, Var msgq))
+                                      (Call atomicMkFn [AsExpr encoreCtxVar, Cast (Ptr ponyActorT) atom]),
+                               --Assign (Decl (encoreActorT, Var new)) (Deref $ Cast (Ptr encoreActorT) atom),
+                               Statement $ Decl (encoreActorT, Var new),
+                               Statement $ Call atomicSetq [Amp (Var new), Cast (Ptr encoreActorT) atom, AsExpr $ Var msgq],
                                Assign (Decl (targetTy, Var old)) atom,
-                               Assign atom (Var new)]
+                               Assign atom (Cast targetTy $ Amp (Var new))]
              atomFnlz = Seq $ [Statement $ Call atomicFinalize [AsExpr encoreCtxVar, Cast (Ptr ponyActorT) atom],
                                Assign atom (Var old)]
          return (unit, Seq [atomInit, Statement tbody, atomFnlz])

--- a/src/ir/AST/AST.hs
+++ b/src/ir/AST/AST.hs
@@ -652,6 +652,10 @@ data Expr = Skip {emeta :: Meta Expr}
           | Match {emeta :: Meta Expr,
                    arg :: Expr,
                    clauses :: [MatchClause]}
+          | Atomic {emeta  :: Meta Expr,
+                    target :: Expr,
+                    name   :: Name,
+                    body   :: Expr}
           | Borrow {emeta  :: Meta Expr,
                     target :: Expr,
                     name   :: Name,

--- a/src/ir/AST/Desugarer.hs
+++ b/src/ir/AST/Desugarer.hs
@@ -290,6 +290,12 @@ desugar Repeat{emeta, name, times, body} =
                               ,decls = [([VarNoType name], readVar "step")]
                               ,body=body}
 
+desugar atomic@(Atomic{emeta, target, name}) =
+  Let{emeta
+     ,mutability = Val
+     ,decls = [([VarNoType name], target)]
+     ,body = atomic}
+
 desugar Async{emeta, body} =
   FunctionCall {emeta, typeArguments=[], qname, args}
   where

--- a/src/ir/AST/PrettyPrinter.hs
+++ b/src/ir/AST/PrettyPrinter.hs
@@ -368,6 +368,10 @@ ppExpr Match {arg, clauses} =
           indent (ppBody mchandler) $+$
         "end"
       ppMatchClauses = foldr (($+$) . indent . ppClause) ""
+ppExpr Atomic {target, name, body} =
+    "atomic" <+> ppExpr target <+> "as" <+> ppName name <+> "in" $+$
+      indent (ppBody body) $+$
+    "end"
 ppExpr Borrow {target, name, body} =
     "borrow" <+> ppExpr target <+> "as" <+> ppName name <+> "in" $+$
       indent (ppBody body) $+$

--- a/src/ir/AST/Util.hs
+++ b/src/ir/AST/Util.hs
@@ -96,6 +96,7 @@ getChildren Match {arg, clauses} = arg:getChildrenClauses clauses
 
     getChildrenClause MatchClause {mcpattern, mchandler, mcguard} =
         [mcpattern, mchandler, mcguard]
+getChildren Atomic {target, body} = [target, body]
 getChildren Borrow {target, body} = [target, body]
 getChildren Get {val} = [val]
 getChildren Forward {forwardExpr} = [forwardExpr]
@@ -177,6 +178,7 @@ putChildren (arg:clauseList) e@(Match {clauses}) =
                 putClausesChildren rest rClauses
           putClausesChildren _ _ =
               error "Util.hs: Wrong number of children of of match clause"
+putChildren [target, body] e@(Atomic {}) = e{target, body}
 putChildren [target, body] e@(Borrow {}) = e{target, body}
 putChildren [val] e@(Get {}) = e{val = val}
 putChildren [forwardExpr] e@(Forward {}) = e{forwardExpr = forwardExpr}
@@ -243,6 +245,7 @@ putChildren _ e@(DoWhile {}) = error "'putChildren l While' expects l to have 2 
 putChildren _ e@(Repeat {}) = error "'putChildren l Repeat' expects l to have 2 elements"
 putChildren _ e@(For {}) = error "'putChildren l For' expects l to have 3 elements"
 putChildren _ e@(Match {}) = error "'putChildren l Match' expects l to have at least 1 element"
+putChildren _ e@(Atomic {}) = error "'putChildren l Atomic' expects l to have 2 elements"
 putChildren _ e@(Borrow {}) = error "'putChildren l Borrow' expects l to have 2 element"
 putChildren _ e@(Get {}) = error "'putChildren l Get' expects l to have 1 element"
 putChildren _ e@(Forward {}) = error "'putChildren l Forward' expects l to have 1 element"

--- a/src/parser/Parser/Parser.hs
+++ b/src/parser/Parser/Parser.hs
@@ -193,6 +193,7 @@ reservedNames =
     ,"and"
     ,"bool"
     ,"break"
+    ,"atomic"
     ,"borrow"
     ,"borrowed"
     ,"case"
@@ -990,6 +991,7 @@ expr = notFollowedBy nl >>
      <|> continue
      <|> closure
      <|> match
+     <|> atomic
      <|> borrow
      <|> blockedTask
      <|> for
@@ -1373,6 +1375,15 @@ expr = notFollowedBy nl >>
           return $ L.IndentSome Nothing (return . Match emeta arg) matchClause
         atLevel indent $ reserved "end"
         returnWithEnd theMatch
+
+      atomic = blockedConstruct $ do
+        emeta <- buildMeta
+        reserved "atomic"
+        target <- expression
+        reserved "as"
+        name <- Name <$> identifier
+        reserved "in"
+        return $ \body -> Atomic{emeta, target, name, body}
 
       borrow = blockedConstruct $ do
         emeta <- buildMeta

--- a/src/runtime/encore/encore.c
+++ b/src/runtime/encore/encore.c
@@ -443,3 +443,23 @@ void encore_trace_object(pony_ctx_t *ctx, void *p, pony_trace_fn f)
   if (!p) { return; }
   ctx->trace_object(ctx, p, &(pony_type_t){.trace = f}, PONY_TRACE_MUTABLE);
 }
+
+void atomiq_init(pony_ctx_t **cctx, pony_actor_t *a)
+{
+  messageq_t *q = pony_alloc(*cctx, sizeof(messageq_t));
+  ponyint_messageq_init(q);
+  pony_msgp_t *msg = ((pony_msgp_t*) pony_alloc_msg(POOL_INDEX(sizeof(pony_msgp_t)), _ENC__MSG_ATOMIC_START));
+  msg->p = q;
+  pony_sendv(*cctx, a, (pony_msg_t*) msg);
+}
+
+void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a)
+{
+  pony_msg_t *msg = (pony_alloc_msg(POOL_INDEX(sizeof(pony_msgp_t)), _ENC__MSG_ATOMIC_START));
+  pony_sendv(*cctx, a, msg);
+}
+
+void atomiq_destroy(messageq_t* q)
+{
+  ponyint_messageq_destroy(q);
+}

--- a/src/runtime/encore/encore.c
+++ b/src/runtime/encore/encore.c
@@ -462,7 +462,7 @@ void* atomiq_init(pony_ctx_t **cctx, pony_actor_t *a)
 
 void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a)
 {
-  pony_msg_t *msg = (pony_alloc_msg(POOL_INDEX(sizeof(pony_msgp_t)), _ENC__MSG_ATOMIC_START));
+  pony_msg_t *msg = (pony_alloc_msg(POOL_INDEX(sizeof(pony_msgp_t)), _ENC__MSG_ATOMIC_STOP));
   pony_sendv(*cctx, a, msg);
   // free the memory for the actor.
   // ponyint_actor_destroy(a);

--- a/src/runtime/encore/encore.c
+++ b/src/runtime/encore/encore.c
@@ -460,7 +460,8 @@ messageq_wrapper_t* atomiq_init(pony_ctx_t **cctx, pony_actor_t *a)
 void atomiq_setq(encore_actor_t *dest, encore_actor_t *src, messageq_wrapper_t *q)
 {
   memcpy(dest, src, sizeof(encore_actor_t));
-  ((pony_actor_t*) dest)->write = (messageq_t*) q;
+  ((pony_actor_t*) dest)->write  = (messageq_t*) q;
+  ((pony_actor_t*) dest)->atomic = src;
 }
 
 void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a)

--- a/src/runtime/encore/encore.c
+++ b/src/runtime/encore/encore.c
@@ -3,6 +3,7 @@
 #include "encore.h"
 #include "closure.h"
 #include "actor/actor.h"
+#include "actor/messageq.h"
 #include "sched/scheduler.h"
 #include "mem/pool.h"
 #include <string.h>
@@ -459,7 +460,7 @@ void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a)
   pony_sendv(*cctx, a, msg);
 }
 
-void atomiq_destroy(messageq_t* q)
+void atomiq_destroy(void* q)
 {
-  ponyint_messageq_destroy(q);
+  ponyint_messageq_destroy((messageq_t*) q);
 }

--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -15,7 +15,6 @@
 #include <platform.h>
 #include <pony.h>
 #include <pony/detail/atomics.h>
-#include "actor/messageq.h"
 
 #define check_receiver(this, op, recv, msg, file)                                   \
   if (!this) {                                                                      \
@@ -196,6 +195,6 @@ static inline void encore_trace_capability(
 
 void atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
 void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a);
-void atomiq_destroy(messageq_t* q);
+void atomiq_destroy(void* q);
 
 #endif /* end of include guard: ENCORE_H_6Q243YHL */

--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -193,8 +193,25 @@ static inline void encore_trace_capability(
   }
 }
 
-void* atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
+typedef struct messageq_wrapper_t
+{
+  void* q;
+} messageq_wrapper_t;
+
+typedef struct atomic_oneway_msg_start
+{
+  encore_oneway_msg_t msg;
+  messageq_wrapper_t* q;
+} atomic_oneway_msg_start_t;
+
+typedef struct atomic_oneway_msg_stop
+{
+  encore_oneway_msg_t msg;
+} atomic_oneway_msg_stop_t;
+
+messageq_wrapper_t* atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
 void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a);
+void atomiq_setq(encore_actor_t *dest, encore_actor_t *src, messageq_wrapper_t *q);
 void atomiq_start(pony_actor_t *a, pony_msg_t *m);
 void atomiq_stop(pony_actor_t *a);
 

--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -15,6 +15,7 @@
 #include <platform.h>
 #include <pony.h>
 #include <pony/detail/atomics.h>
+#include "actor/messageq.h"
 
 #define check_receiver(this, op, recv, msg, file)                                   \
   if (!this) {                                                                      \
@@ -70,6 +71,8 @@ typedef enum {
   _ENC__MSG_RESUME_SUSPEND,
   _ENC__MSG_RESUME_AWAIT,
   _ENC__MSG_RUN_CLOSURE,
+  _ENC__MSG_ATOMIC_START,
+  _ENC__MSG_ATOMIC_STOP,
   _ENC__MSG_MAIN,
 } encore_msg_id;
 
@@ -190,5 +193,9 @@ static inline void encore_trace_capability(
     encore_trace_object(ctx, p, ((capability_t*) p)->_enc__self_type->trace);
   }
 }
+
+void atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
+void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a);
+void atomiq_destroy(messageq_t* q);
 
 #endif /* end of include guard: ENCORE_H_6Q243YHL */

--- a/src/runtime/encore/encore.h
+++ b/src/runtime/encore/encore.h
@@ -193,8 +193,9 @@ static inline void encore_trace_capability(
   }
 }
 
-void atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
+void* atomiq_init(pony_ctx_t **cctx, pony_actor_t *a);
 void atomiq_finalize(pony_ctx_t **cctx, pony_actor_t *a);
-void atomiq_destroy(void* q);
+void atomiq_start(pony_actor_t *a, pony_msg_t *m);
+void atomiq_stop(pony_actor_t *a);
 
 #endif /* end of include guard: ENCORE_H_6Q243YHL */

--- a/src/runtime/pony/libponyrt/actor/actor.c
+++ b/src/runtime/pony/libponyrt/actor/actor.c
@@ -195,8 +195,10 @@ bool ponyint_actor_run(pony_ctx_t** ctx, pony_actor_t* actor, size_t batch)
   }
 
   // If we have been scheduled, the head will not be marked as empty.
-  pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed);
-  while((msg = ponyint_messageq_pop(&actor->q)) != NULL)
+  /* pony_msg_t* head = atomic_load_explicit(&actor->q.head, memory_order_relaxed); */
+  /* while((msg = ponyint_messageq_pop(&actor->q)) != NULL) */
+  pony_msg_t* head = atomic_load_explicit(&actor->read->head, memory_order_relaxed);
+  while((msg = ponyint_messageq_pop(actor->read)) != NULL)
   {
     if(handle_message(ctx, actor, msg))
     {
@@ -241,7 +243,8 @@ bool ponyint_actor_run(pony_ctx_t** ctx, pony_actor_t* actor, size_t batch)
   }
 
   // Return true (i.e. reschedule immediately) if our queue isn't empty.
-  return !ponyint_messageq_markempty(&actor->q);
+  // return !ponyint_messageq_markempty(&actor->q);
+  return !ponyint_messageq_markempty(actor->read);
 }
 
 void ponyint_actor_destroy(pony_actor_t* actor)
@@ -344,6 +347,8 @@ pony_actor_t* pony_create(pony_ctx_t* ctx, pony_type_t* type)
   ponyint_messageq_init(&actor->q);
   ponyint_heap_init(&actor->heap);
   ponyint_gc_done(&actor->gc);
+  actor->read = &actor->q;
+  actor->write = &actor->q;
 
   if(actor_noblock)
     ponyint_actor_setsystem(actor);
@@ -387,7 +392,8 @@ void pony_sendv(pony_ctx_t* ctx, pony_actor_t* to, pony_msg_t* m)
 {
   DTRACE2(ACTOR_MSG_SEND, (uintptr_t)ctx->scheduler, m->id);
 
-  if(ponyint_messageq_push(&to->q, m))
+  // if(ponyint_messageq_push(&to->q, m))
+  if(ponyint_messageq_push(to->write, m))
   {
     if(!has_flag(to, FLAG_UNSCHEDULED))
       ponyint_sched_add(ctx, to);

--- a/src/runtime/pony/libponyrt/actor/actor.h
+++ b/src/runtime/pony/libponyrt/actor/actor.h
@@ -22,6 +22,8 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
+  messageq_t* read;
+  messageq_t* write;
   pony_msg_t* continuation;
   uint8_t flags;
 

--- a/src/runtime/pony/libponyrt/actor/actor.h
+++ b/src/runtime/pony/libponyrt/actor/actor.h
@@ -22,6 +22,7 @@ typedef struct pony_actor_t
 {
   pony_type_t* type;
   messageq_t q;
+  void* atomic;
   messageq_t* read;
   messageq_t* write;
   pony_msg_t* continuation;

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -1174,12 +1174,8 @@ instance Checkable Expr where
     doTypecheck atomic@(Atomic{emeta, target, name, body}) = do
       eTarget <- typecheck target
       let targetTy = AST.getType eTarget
-          decls = [([VarType {varName = name, varType = AST.getType eTarget}], eTarget)]
-          letExpr = Let{emeta = emeta, mutability = Val, decls = decls, body = body}
-      eLetExpr <- typecheck letExpr
-      let eBody = extractBody eLetExpr
-          bodyTy = AST.getType eBody
-          extractBody Let{body} = body
+      eBody <- typecheck body
+      let bodyTy = AST.getType eBody
       isActive <- isActiveType targetTy
       unless isActive $
              pushError eTarget $ ExpectingOtherTypeError "target to be an active object" targetTy

--- a/src/types/Typechecker/Typechecker.hs
+++ b/src/types/Typechecker/Typechecker.hs
@@ -1176,8 +1176,10 @@ instance Checkable Expr where
       let targetTy = AST.getType eTarget
           decls = [([VarType {varName = name, varType = AST.getType eTarget}], eTarget)]
           letExpr = Let{emeta = emeta, mutability = Val, decls = decls, body = body}
-      eBody <- typecheck letExpr
-      let bodyTy = AST.getType eBody
+      eLetExpr <- typecheck letExpr
+      let eBody = extractBody eLetExpr
+          bodyTy = AST.getType eBody
+          extractBody Let{body} = body
       isActive <- isActiveType targetTy
       unless isActive $
              pushError eTarget $ ExpectingOtherTypeError "target to be an active object" targetTy


### PR DESCRIPTION
The pony actor is given two pointers to a read and write queue. An actor reads from the read queue and messages sent to actors are put in the write queue. When using atomic a shallow copy of the target actor is created on the stack plus new queue, and the actor swaps its write queue pointer for it allowing exclusive access. The copy can then swap its write queue to the new queue as well. At the end of the atomic block the write queue is reset. The atomic void pointer in the pony actor is so the copy knows who the original actor is when scheduling.